### PR TITLE
Temporary fix for typed-arena version regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: cargo
 
 rust:
   - 1.32.0
+  - 1.36.0 # FIXME: version regression https://github.com/SimonSapin/rust-typed-arena/issues/31
   - stable
   - beta
   - nightly
@@ -10,4 +11,5 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+    - rust: 1.32.0 # FIXME: version regression https://github.com/SimonSapin/rust-typed-arena/issues/31
   fast_finish: true


### PR DESCRIPTION
Due to a Rust [version regression in `typed-arena`](https://github.com/SimonSapin/rust-typed-arena/issues/31) we can now only support Rust 1.36.  This adds a temporary minimum version of Rust 1.36, and allows failures for Rust 1.32 until this is resolved.