### PR TITLE
Revert typed-arena workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: cargo
 
 rust:
   - 1.32.0
-  - 1.36.0 # FIXME: version regression https://github.com/SimonSapin/rust-typed-arena/issues/31
   - stable
   - beta
   - nightly
@@ -11,5 +10,4 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
-    - rust: 1.32.0 # FIXME: version regression https://github.com/SimonSapin/rust-typed-arena/issues/31
   fast_finish: true


### PR DESCRIPTION
Now that SimonSapin/rust-typed-arena#33 has been merged, we should now be able to compile on Rust 1.32 again.