### PR TITLE
Bump minimum Rust to 1.36.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 cache: cargo
 
 rust:
-  - 1.32.0
+  - 1.36.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
See the discussion at servo/string-cache#228.