### PR TITLE
Avoid caching the target directory during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: rust
-cache: cargo
+cache:
+  directories:
+    - $HOME/.cargo
+
+    # Don't cache the target directory. It gets rather large, and the
+    # unpacking of this ends up taking a rather long time!
+    # - $TRAVIS_BUILD_DIR/target
 
 rust:
   - 1.36.0


### PR DESCRIPTION
The travis caches are currently between 5 and 10Gb and the build spends a lot of time (about 6 mins x 2) downloading and unpacking before the build and packing and uploading afterwards.