### PR TITLE
Update and fix HarfBuzz links

### DIFF
--- a/docs/specification/references.md
+++ b/docs/specification/references.md
@@ -81,7 +81,7 @@ structures, such as file formats, network protocols or bitstreams.
   the Open Type Font specification. Shows promise as nice way to describe
   binary formats, but JS is not the most flexible host language.
 - [HarfBuzz](https://github.com/harfbuzz/harfbuzz) defines [a handy set of types
-  and macros](https://github.com/harfbuzz/harfbuzz/blob/35218c488c3966aa6d459ec5a007a2b43208e97c/src/hb-machinery.hh#L40-L92)
+  and macros](https://github.com/harfbuzz/harfbuzz/blob/35218c488c3966aa6d459ec5a007a2b43208e97c/src/hb-machinery.hh)
   that allows binary data to be cast in-place into declaratively descibed Open
   Type Font tables. Alas, it is in C++, and the API seems extremely prone to
   human-error. A Rust API would be much more robust in regards to upholding

--- a/docs/specification/references.md
+++ b/docs/specification/references.md
@@ -80,8 +80,8 @@ structures, such as file formats, network protocols or bitstreams.
   EDSL. Used in [fontkit](https://github.com/devongovett/fontkit) for describing
   the Open Type Font specification. Shows promise as nice way to describe
   binary formats, but JS is not the most flexible host language.
-- [Harfbuzz](https://github.com/behdad/harfbuzz) defines [a handy set of types
-  and macros](https://github.com/behdad/harfbuzz/blob/master/src/hb-open-type-private.hh)
+- [HarfBuzz](https://github.com/harfbuzz/harfbuzz) defines [a handy set of types
+  and macros](https://github.com/harfbuzz/harfbuzz/blob/35218c488c3966aa6d459ec5a007a2b43208e97c/src/hb-machinery.hh#L40-L92)
   that allows binary data to be cast in-place into declaratively descibed Open
   Type Font tables. Alas, it is in C++, and the API seems extremely prone to
   human-error. A Rust API would be much more robust in regards to upholding


### PR DESCRIPTION
* Update the HarfBuzz links to use the latest repository. Since GitHub redirects the old <https://github.com/behdad/harfbuzz> to the new <https://github.com/harfbuzz/harfbuzz>, this is merely a nice-to-have.
* Fix the broken “a handy set of types and macros” link. The `hb-open-type-private.hh` file was split into multiple files and no longer exists. I've gleaned that the relevant change occurred in https://github.com/harfbuzz/harfbuzz/commit/92b1e025c639d006f55400bf68fc23bdeaa1c716. 🚧**Please verify that the new link points to the intended code.**