### PR TITLE
Make aliases transparent

### DIFF
--- a/crates/ddl/src/core/compile/rust/mod.rs
+++ b/crates/ddl/src/core/compile/rust/mod.rs
@@ -177,6 +177,7 @@ fn compile_alias<'item>(
                     None => unreachable!("type level if for non-format type"),
                     Some(host_ty) => {
                         // Should we be using `ty` somewhere here?
+                        // FIXME: Coercions between definitionally equal aliases?
                         let rust_item = rust::Item::Struct(rust::StructType {
                             derives: derives(ty.is_copy),
                             doc,

--- a/crates/ddl/src/core/grammar.lalrpop
+++ b/crates/ddl/src/core/grammar.lalrpop
@@ -63,6 +63,7 @@ Item: Item = {
     <start: @L> <name: "identifier"> "=" <term: Term> ";" <end: @R> => {
         let span = Span::new(start, end);
         let doc = Arc::from(doc);
+        let term = Arc::new(term);
 
         Item::Alias(Alias { span, doc, name, term })
     },
@@ -83,6 +84,7 @@ Field: TypeField = {
     <doc: "doc comment"*>
     <start: @L> <name: "identifier"> ":" <term: Term> => {
         let doc = Arc::from(doc);
+        let term = Arc::new(term);
 
         TypeField { doc, start, name, term }
     },

--- a/crates/ddl/src/core/mod.rs
+++ b/crates/ddl/src/core/mod.rs
@@ -126,7 +126,7 @@ pub struct Alias {
     /// Name of this definition.
     pub name: String,
     /// The term that is aliased.
-    pub term: Term,
+    pub term: Arc<Term>,
 }
 
 impl Alias {
@@ -229,7 +229,7 @@ pub struct TypeField {
     pub doc: Arc<[String]>,
     pub start: ByteIndex,
     pub name: String,
-    pub term: Term,
+    pub term: Arc<Term>,
 }
 
 impl TypeField {

--- a/crates/ddl/src/surface/delaborate.rs
+++ b/crates/ddl/src/surface/delaborate.rs
@@ -21,7 +21,7 @@ pub fn delaborate_module(module: &core::Module) -> surface::Module {
 pub fn delaborate_item(item: &core::Item) -> surface::Item {
     match item {
         core::Item::Alias(alias) => {
-            let (term, ty) = match &alias.term {
+            let (term, ty) = match alias.term.as_ref() {
                 core::Term::Ann(term, ty) => (delaborate_term(term), Some(delaborate_term(ty))),
                 term => (delaborate_term(term), None),
             };

--- a/tests/input/alias/pass_if_else_format_type_item.rs
+++ b/tests/input/alias/pass_if_else_format_type_item.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
-// use ddl_test_util::ddl::binary;
 use ddl_rt::{F64Be, FormatWriter, ReadError, ReadScope, U8};
+use ddl_test_util::ddl::{binary, core};
 
 #[path = "../../snapshots/alias/pass_if_else_format_type_item.rs"]
 mod fixture;
@@ -32,17 +32,16 @@ fn valid_test() {
     let mut writer = FormatWriter::new(vec![]);
     writer.write::<F64Be>(23.64e10); // Test::inner
 
+    let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
     let singleton = read_scope.read::<fixture::Test>().unwrap();
+    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    // FIXME(#162): Requires us to evaluate items!
-    // let mut read_context = binary::read::Context::new(read_scope.reader());
-    // let test = binary::read::read_module_item(&FIXTURE, &"Test", &mut read_scope.reader()).unwrap();
-
+    let test = binary::read::read_module_item(&mut read_context, &FIXTURE, &"Test").unwrap();
     match singleton.inner() {
         fixture::Enum0::True(inner) => {
             assert_eq!(inner, 23.64e10);
-            // assert_eq!(test, binary::Term::F64(inner));
+            assert_eq!(test, binary::Term::F64(inner));
         }
         _ => panic!("expected `Enum0::True(_)`"),
     }
@@ -56,17 +55,16 @@ fn valid_test_trailing() {
     writer.write::<F64Be>(781.453298); // Test::inner
     writer.write::<U8>(42);
 
+    let globals = core::Globals::default();
     let read_scope = ReadScope::new(writer.buffer());
     let singleton = read_scope.read::<fixture::Test>().unwrap();
+    let mut read_context = binary::read::Context::new(&globals, read_scope.reader());
 
-    // FIXME(#162): Requires us to evaluate items!
-    // let mut read_context = binary::read::Context::new(read_scope.reader());
-    // let test = binary::read::read_module_item(&FIXTURE, &"Test", &mut read_scope.reader()).unwrap();
-
+    let test = binary::read::read_module_item(&mut read_context, &FIXTURE, &"Test").unwrap();
     match singleton.inner() {
         fixture::Enum0::True(inner) => {
             assert_eq!(inner, 781.453298);
-            // assert_eq!(test, binary::Term::F64(inner));
+            assert_eq!(test, binary::Term::F64(inner));
         }
         _ => panic!("expected `Enum0::True(_)`"),
     }


### PR DESCRIPTION
We now pass items through to the evaluator, allowing us to resolve aliases to the terms they point to. This mirrors the way that type aliases work in Rust. We might need to be careful about what happens when wrapper structs are generated in the Rust backend, but I’ll leave that to another day!

Closes #162.