### PR TITLE
Use codespan-reporting only, removing codespan

### DIFF
--- a/crates/ddl-test-util/Cargo.toml
+++ b/crates/ddl-test-util/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-codespan = "0.9.2"
 codespan-reporting =  "0.9.2"
 ddl = { version = "0.1.0", path = "../ddl" }
 lazy_static = "1.4"

--- a/crates/ddl-test-util/src/lib.rs
+++ b/crates/ddl-test-util/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![warn(rust_2018_idioms)]
 
-pub use codespan;
+pub use codespan_reporting;
 pub use ddl;
 pub use lazy_static;
 
@@ -13,7 +13,7 @@ macro_rules! core_module {
             static ref $IDENT: $crate::ddl::core::Module = {
                 use std::fs;
 
-                let mut files = $crate::codespan::Files::new();
+                let mut files = $crate::codespan_reporting::files::SimpleFiles::new();
                 const SOURCE: &str = include_str!($path);
                 let file_id = files.add($path.to_string(), SOURCE.to_string());
 

--- a/crates/ddl-test/Cargo.toml
+++ b/crates/ddl-test/Cargo.toml
@@ -12,7 +12,6 @@ license = "Apache-2.0"
 
 [dev-dependencies]
 assert_fs = "1.0"
-codespan =  "0.9.2"
 codespan-reporting =  "0.9.2"
 ddl = { version = "0.1.0", path = "../ddl" }
 ddl-rt = { version = "0.1.0", path = "../ddl-rt" }

--- a/crates/ddl-test/src/support/directives/mod.rs
+++ b/crates/ddl-test/src/support/directives/mod.rs
@@ -1,7 +1,8 @@
-use codespan::{ByteIndex, ByteOffset, FileId, LineIndex, Span};
 use codespan_reporting::diagnostic::Severity;
+use codespan_reporting::files::Location;
 use regex::Regex;
 use std::fmt;
+use std::ops::Range;
 
 mod lexer;
 mod parser;
@@ -41,8 +42,9 @@ impl Default for Directives {
 
 #[derive(Clone, Debug)]
 pub struct ExpectedDiagnostic {
-    pub file_id: FileId,
-    pub line: LineIndex,
+    pub file_id: usize,
+    pub line_index: usize,
+    pub location: Location,
     pub severity: Severity,
     pub pattern: Regex,
 }
@@ -50,23 +52,20 @@ pub struct ExpectedDiagnostic {
 /// A string that is located in a source file.
 #[derive(Debug, Clone)]
 pub struct SpannedString {
-    pub start: ByteIndex,
+    pub start: usize,
     pub inner: String,
 }
 
 impl SpannedString {
-    pub fn new(start: impl Into<ByteIndex>, inner: impl Into<String>) -> SpannedString {
+    pub fn new(start: impl Into<usize>, inner: impl Into<String>) -> SpannedString {
         SpannedString {
             start: start.into(),
             inner: inner.into(),
         }
     }
 
-    pub fn span(&self) -> Span {
-        Span::new(
-            self.start,
-            self.start + ByteOffset::from_str_len(&self.inner),
-        )
+    pub fn range(&self) -> Range<usize> {
+        self.start..(self.start + self.inner.len())
     }
 
     pub fn as_str(&self) -> &str {

--- a/crates/ddl-test/src/support/directives/parser.rs
+++ b/crates/ddl-test/src/support/directives/parser.rs
@@ -1,17 +1,18 @@
-use codespan::{FileId, Files, Span};
 use codespan_reporting::diagnostic::{Diagnostic, Label, Severity};
+use codespan_reporting::files::{Files, SimpleFiles};
+use std::ops::Range;
 
 use super::{Directives, ExpectedDiagnostic, SpannedString, Token};
 
 pub struct Parser<'a> {
-    files: &'a Files<String>,
-    file_id: FileId,
+    files: &'a SimpleFiles<String, String>,
+    file_id: usize,
     directives: Directives,
-    diagnostics: Vec<Diagnostic<FileId>>,
+    diagnostics: Vec<Diagnostic<usize>>,
 }
 
 impl<'a> Parser<'a> {
-    pub fn new(files: &'a Files<String>, file_id: FileId) -> Parser<'a> {
+    pub fn new(files: &'a SimpleFiles<String, String>, file_id: usize) -> Parser<'a> {
         Parser {
             files,
             file_id,
@@ -22,31 +23,31 @@ impl<'a> Parser<'a> {
 
     pub fn expect_directives(
         &mut self,
-        tokens: impl Iterator<Item = Result<Token, Diagnostic<FileId>>>,
+        tokens: impl Iterator<Item = Result<Token, Diagnostic<usize>>>,
     ) {
         for directive in tokens {
             match directive {
-                Ok((span, key, value)) => match (key.as_str(), value) {
+                Ok((range, key, value)) => match (key.as_str(), value) {
                     ("SKIP", reason) => match reason {
                         None => self.diagnostics.push(
                             Diagnostic::error()
                                 .with_message("`SKIP` directive must have a reason")
-                                .with_labels(vec![self.label(span, "missing skip reason")]),
+                                .with_labels(vec![self.label(range, "missing skip reason")]),
                         ),
                         Some(_) if self.directives.skip.is_some() => {
                             self.duplicate_directive(&key);
                         }
                         Some(reason) => self.directives.skip = Some(reason.to_string()),
                     },
-                    ("bug", pattern) => self.expect_bug(span, pattern),
-                    ("error", pattern) => self.expect_error(span, pattern),
-                    ("warning", pattern) => self.expect_warning(span, pattern),
-                    ("note", pattern) => self.expect_note(span, pattern),
-                    ("help", pattern) => self.expect_help(span, pattern),
+                    ("bug", pattern) => self.expect_bug(range, pattern),
+                    ("error", pattern) => self.expect_error(range, pattern),
+                    ("warning", pattern) => self.expect_warning(range, pattern),
+                    ("note", pattern) => self.expect_note(range, pattern),
+                    ("help", pattern) => self.expect_help(range, pattern),
                     (_, _) => self.diagnostics.push(
                         Diagnostic::error()
                             .with_message(format!("unknown directive `{}`", key))
-                            .with_labels(vec![self.label(key.span(), "unknown directive")])
+                            .with_labels(vec![self.label(key.range(), "unknown directive")])
                             .with_notes(vec![unindent::unindent(
                                 "
                                     perhaps you meant:
@@ -65,61 +66,55 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub fn finish(self) -> (Directives, Vec<Diagnostic<FileId>>) {
+    pub fn finish(self) -> (Directives, Vec<Diagnostic<usize>>) {
         (self.directives, self.diagnostics)
     }
 
-    fn label(&self, span: Span, message: impl Into<String>) -> Label<FileId> {
-        Label::primary(self.file_id, span.start().to_usize()..span.end().to_usize())
-            .with_message(message)
+    fn label(&self, range: Range<usize>, message: impl Into<String>) -> Label<usize> {
+        Label::primary(self.file_id, range).with_message(message)
     }
 
     fn duplicate_directive(&mut self, directive: &SpannedString) {
         self.diagnostics.push(
             Diagnostic::error()
                 .with_message(format!("`{}` directive already set", directive))
-                .with_labels(vec![self.label(directive.span(), "duplicate directive")]),
+                .with_labels(vec![self.label(directive.range(), "duplicate directive")]),
         );
     }
 
-    fn expect_bug(&mut self, span: Span, pattern: Option<SpannedString>) {
-        self.expect_diagnostic(span, Severity::Bug, pattern);
+    fn expect_bug(&mut self, range: Range<usize>, pattern: Option<SpannedString>) {
+        self.expect_diagnostic(range, Severity::Bug, pattern);
     }
 
-    fn expect_error(&mut self, span: Span, pattern: Option<SpannedString>) {
-        self.expect_diagnostic(span, Severity::Error, pattern);
+    fn expect_error(&mut self, range: Range<usize>, pattern: Option<SpannedString>) {
+        self.expect_diagnostic(range, Severity::Error, pattern);
     }
 
-    fn expect_warning(&mut self, span: Span, pattern: Option<SpannedString>) {
-        self.expect_diagnostic(span, Severity::Warning, pattern);
+    fn expect_warning(&mut self, range: Range<usize>, pattern: Option<SpannedString>) {
+        self.expect_diagnostic(range, Severity::Warning, pattern);
     }
 
-    fn expect_note(&mut self, span: Span, pattern: Option<SpannedString>) {
-        self.expect_diagnostic(span, Severity::Note, pattern);
+    fn expect_note(&mut self, range: Range<usize>, pattern: Option<SpannedString>) {
+        self.expect_diagnostic(range, Severity::Note, pattern);
     }
 
-    fn expect_help(&mut self, span: Span, pattern: Option<SpannedString>) {
-        self.expect_diagnostic(span, Severity::Help, pattern);
+    fn expect_help(&mut self, range: Range<usize>, pattern: Option<SpannedString>) {
+        self.expect_diagnostic(range, Severity::Help, pattern);
     }
 
     fn expect_diagnostic(
         &mut self,
-        span: Span,
+        range: Range<usize>,
         severity: Severity,
         pattern: Option<SpannedString>,
     ) {
         use regex::Regex;
         use std::str::FromStr;
 
-        let location = self
-            .files
-            .location(self.file_id, span.start())
-            .expect("diagnostic_location");
-
         let pattern = match pattern {
             None => Ok(Regex::from_str(".*").unwrap()),
             Some(pattern) => {
-                Regex::from_str(pattern.as_str()).map_err(|error| (pattern.span(), error))
+                Regex::from_str(pattern.as_str()).map_err(|error| (pattern.range(), error))
             }
         };
 
@@ -129,16 +124,17 @@ impl<'a> Parser<'a> {
                     .expected_diagnostics
                     .push(ExpectedDiagnostic {
                         file_id: self.file_id,
-                        line: location.line,
+                        line_index: self.files.line_index(self.file_id, range.start).unwrap(),
+                        location: self.files.location(self.file_id, range.start).unwrap(),
                         severity,
                         pattern,
                     });
             }
-            Err((pattern_span, error)) => {
+            Err((pattern_range, error)) => {
                 self.diagnostics.push(
                     Diagnostic::error()
                         .with_message("failed to compile regex")
-                        .with_labels(vec![self.label(pattern_span, "invalid regex")])
+                        .with_labels(vec![self.label(pattern_range, "invalid regex")])
                         .with_notes(vec![error.to_string()]),
                 );
             }

--- a/crates/ddl/Cargo.toml
+++ b/crates/ddl/Cargo.toml
@@ -12,7 +12,6 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-codespan = "0.9.2"
 codespan-reporting = "0.9.2"
 ddl-rt = { version = "0.1.0", path="../ddl-rt" }
 inflector = { package = "Inflector", version = "0.11" }

--- a/crates/ddl/src/core/compile/rust/diagnostics.rs
+++ b/crates/ddl/src/core/compile/rust/diagnostics.rs
@@ -1,28 +1,28 @@
 //! Diagnostics.
 
-use codespan::{FileId, Span};
 use codespan_reporting::diagnostic::{Diagnostic, Label, Severity};
+use std::ops::Range;
 
 pub fn non_format_type_as_host_type(
     severity: Severity,
-    file_id: FileId,
-    span: Span,
-) -> Diagnostic<FileId> {
+    file_id: usize,
+    range: Range<usize>,
+) -> Diagnostic<usize> {
     Diagnostic::new(severity)
         .with_message("attempted to compile a non-format type as a host type")
         .with_labels(vec![
-            Label::primary(file_id, span).with_message("not a format type")
+            Label::primary(file_id, range).with_message("not a format type")
         ])
 }
 
 pub mod error {
     use super::*;
 
-    pub fn unconstrained_int(file_id: FileId, span: Span) -> Diagnostic<FileId> {
+    pub fn unconstrained_int(file_id: usize, range: Range<usize>) -> Diagnostic<usize> {
         Diagnostic::error()
             .with_message("cannot compile unconstrained integer types")
             .with_labels(vec![
-                Label::primary(file_id, span).with_message("unconstrained integer type")
+                Label::primary(file_id, range).with_message("unconstrained integer type")
             ])
     }
 }
@@ -31,11 +31,11 @@ pub mod bug {
     pub use super::*;
 
     pub fn item_name_reused(
-        file_id: FileId,
+        file_id: usize,
         name: &str,
-        found: Span,
-        original: Span,
-    ) -> Diagnostic<FileId> {
+        found: Range<usize>,
+        original: Range<usize>,
+    ) -> Diagnostic<usize> {
         Diagnostic::bug()
             .with_message(format!(
                 "attempted to compile an item named `{}` multiple times",
@@ -51,54 +51,54 @@ pub mod bug {
             )])
     }
 
-    pub fn oversaturated_fun_elim(file_id: FileId, span: Span) -> Diagnostic<FileId> {
+    pub fn oversaturated_fun_elim(file_id: usize, range: Range<usize>) -> Diagnostic<usize> {
         Diagnostic::bug()
             .with_message("attempted to compile an oversaturated function elimination")
             .with_labels(vec![
-                Label::primary(file_id, span).with_message("too many eliminations")
+                Label::primary(file_id, range).with_message("too many eliminations")
             ])
     }
 
-    pub fn unexpected_elim(file_id: FileId, span: Span) -> Diagnostic<FileId> {
+    pub fn unexpected_elim(file_id: usize, range: Range<usize>) -> Diagnostic<usize> {
         Diagnostic::bug()
             .with_message("unexpected elimination")
             .with_labels(vec![
-                Label::primary(file_id, span).with_message("unexpected elimination")
+                Label::primary(file_id, range).with_message("unexpected elimination")
             ])
     }
 
-    pub fn integer_out_of_bounds(file_id: FileId, span: Span) -> Diagnostic<FileId> {
+    pub fn integer_out_of_bounds(file_id: usize, range: Range<usize>) -> Diagnostic<usize> {
         Diagnostic::bug()
             .with_message("attempted to compile an out of bounds integer")
             .with_labels(vec![
-                Label::primary(file_id, span).with_message("integer out of bounds")
+                Label::primary(file_id, range).with_message("integer out of bounds")
             ])
     }
 
-    pub fn expected_integer(file_id: FileId, span: Span) -> Diagnostic<FileId> {
+    pub fn expected_integer(file_id: usize, range: Range<usize>) -> Diagnostic<usize> {
         Diagnostic::bug()
             .with_message("attempted to compile this expression as an integer")
             .with_labels(vec![
-                Label::primary(file_id, span).with_message("not an integer")
+                Label::primary(file_id, range).with_message("not an integer")
             ])
     }
 
-    pub fn expected_type(file_id: FileId, span: Span) -> Diagnostic<FileId> {
+    pub fn expected_type(file_id: usize, range: Range<usize>) -> Diagnostic<usize> {
         Diagnostic::bug()
             .with_message("attempted to compile this expression as a type")
             .with_labels(vec![
-                Label::primary(file_id, span).with_message("not a type")
+                Label::primary(file_id, range).with_message("not a type")
             ])
     }
 
-    pub fn unbound_item(file_id: FileId, name: &str, span: Span) -> Diagnostic<FileId> {
+    pub fn unbound_item(file_id: usize, name: &str, range: Range<usize>) -> Diagnostic<usize> {
         Diagnostic::bug()
             .with_message(format!(
                 "attempted to compile an item `{}` that was not yet bound",
                 name,
             ))
             .with_labels(vec![
-                Label::primary(file_id, span).with_message("item not found in this scope")
+                Label::primary(file_id, range).with_message("item not found in this scope")
             ])
         // TODO: provide suggestions
     }

--- a/crates/ddl/src/core/grammar.lalrpop
+++ b/crates/ddl/src/core/grammar.lalrpop
@@ -1,4 +1,3 @@
-use codespan::{ByteIndex, FileId, Span};
 use codespan_reporting::diagnostic::Diagnostic;
 use std::sync::Arc;
 
@@ -6,11 +5,11 @@ use crate::core::{Alias, Constant, Item, Module, Universe, StructType, Term, Typ
 use crate::lexer::Token;
 use crate::literal;
 
-grammar(file_id: FileId, report: &mut dyn FnMut(Diagnostic<FileId>));
+grammar(file_id: usize, report: &mut dyn FnMut(Diagnostic<usize>));
 
 extern {
-    type Location = ByteIndex;
-    type Error = Diagnostic<FileId>;
+    type Location = usize;
+    type Error = Diagnostic<usize>;
 
     enum Token {
         "doc comment" => Token::DocComment(<String>),
@@ -62,22 +61,22 @@ pub Module: Module = {
 Item: Item = {
     <doc: "doc comment"*>
     <start: @L> <name: "identifier"> "=" <term: Term> ";" <end: @R> => {
-        let span = Span::new(start, end);
+        let range = start..end;
         let doc = Arc::from(doc);
         let term = Arc::new(term);
 
-        Item::Alias(Alias { span, doc, name, term })
+        Item::Alias(Alias { range, doc, name, term })
     },
     <docs: "doc comment"*>
     <start: @L> "struct" <name: "identifier">  "{"
         <mut fields: (<Field> ",")*>
         <last: Field?>
     "}" <end: @R> => {
-        let span = Span::new(start, end);
+        let range = start..end;
         let doc = Arc::from(docs);
         fields.extend(last);
 
-        Item::Struct(StructType { span, doc, name, fields })
+        Item::Struct(StructType { range, doc, name, fields })
     },
 };
 
@@ -112,14 +111,14 @@ AppTerm: Term = {
 
 AtomicTerm: Term = {
     "(" <term: Term> ")" => term,
-    <start: @L> "!" <end: @R> => Term::Error(Span::new(start, end)),
-    <start: @L> "global" <name: "identifier"> <end: @R> => Term::Global(Span::new(start, end), name),
-    <start: @L> "item" <name: "identifier"> <end: @R> => Term::Item(Span::new(start, end), name),
-    <start: @L> "Host" <end: @R> => Term::Universe(Span::new(start, end), Universe::Host),
-    <start: @L> "Format" <end: @R> => Term::Universe(Span::new(start, end), Universe::Format),
-    <start: @L> "Kind" <end: @R> => Term::Universe(Span::new(start, end), Universe::Kind),
+    <start: @L> "!" <end: @R> => Term::Error(start..end),
+    <start: @L> "global" <name: "identifier"> <end: @R> => Term::Global(start..end, name),
+    <start: @L> "item" <name: "identifier"> <end: @R> => Term::Item(start..end, name),
+    <start: @L> "Host" <end: @R> => Term::Universe(start..end, Universe::Host),
+    <start: @L> "Format" <end: @R> => Term::Universe(start..end, Universe::Format),
+    <start: @L> "Kind" <end: @R> => Term::Universe(start..end, Universe::Kind),
     <start: @L> "bool_elim" <head: Term> "{" <if_true: Term> "," <if_false: Term> "}" <end: @R> => {
-        Term::BoolElim(Span::new(start, end), Arc::new(head), Arc::new(if_true), Arc::new(if_false))
+        Term::BoolElim(start..end, Arc::new(head), Arc::new(if_true), Arc::new(if_false))
     },
     <start: @L> "int_elim" <head: Term> "{" <branches: (<"numeric literal"> "=>" <Term> ",")*> <default: Term> "}" <end: @R> => {
         let branches = branches
@@ -128,27 +127,27 @@ AtomicTerm: Term = {
                 Some((literal.parse_big_int(file_id, report)?, Arc::new(term)))
             }).collect();
 
-        Term::IntElim(Span::new(start, end), Arc::new(head), branches, Arc::new(default))
+        Term::IntElim(start..end, Arc::new(head), branches, Arc::new(default))
     },
     <start: @L> "int" <literal: "numeric literal"> <end: @R> => {
-        let span = Span::new(start, end);
+        let range = start..end;
         match literal.parse_big_int(file_id, report) {
-            Some(value) => Term::Constant(span, Constant::Int(value)),
-            None => Term::Error(span),
+            Some(value) => Term::Constant(range, Constant::Int(value)),
+            None => Term::Error(range),
         }
     },
     <start: @L> "f32" <literal: "numeric literal"> <end: @R> => {
-        let span = Span::new(start, end);
+        let range = start..end;
         match literal.parse_float(file_id, report) {
-            Some(value) => Term::Constant(span, Constant::F32(value)),
-            None => Term::Error(span),
+            Some(value) => Term::Constant(range, Constant::F32(value)),
+            None => Term::Error(range),
         }
     },
     <start: @L> "f64" <literal: "numeric literal"> <end: @R> => {
-        let span = Span::new(start, end);
+        let range = start..end;
         match literal.parse_float(file_id, report) {
-            Some(value) => Term::Constant(span, Constant::F64(value)),
-            None => Term::Error(span),
+            Some(value) => Term::Constant(range, Constant::F64(value)),
+            None => Term::Error(range),
         }
     },
 };

--- a/crates/ddl/src/surface/compile/doc.rs
+++ b/crates/ddl/src/surface/compile/doc.rs
@@ -1,4 +1,3 @@
-use codespan::FileId;
 use codespan_reporting::diagnostic::Diagnostic;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -11,7 +10,7 @@ use crate::surface::pretty::Prec;
 pub fn compile_module(
     writer: &mut impl Write,
     module: &surface::Module,
-    report: &mut dyn FnMut(Diagnostic<FileId>),
+    report: &mut dyn FnMut(Diagnostic<usize>),
 ) -> io::Result<()> {
     let mut context = ModuleContext {
         _file_id: module.file_id,
@@ -80,7 +79,7 @@ pub fn compile_module(
 }
 
 struct ModuleContext {
-    _file_id: FileId,
+    _file_id: usize,
     items: HashMap<String, Item>,
 }
 
@@ -92,7 +91,7 @@ fn compile_alias(
     context: &ModuleContext,
     writer: &mut impl Write,
     alias: &surface::Alias,
-    report: &mut dyn FnMut(Diagnostic<FileId>),
+    report: &mut dyn FnMut(Diagnostic<usize>),
 ) -> io::Result<(String, Item)> {
     let (_, name) = &alias.name;
     let id = format!("items[{}]", name);
@@ -149,7 +148,7 @@ fn compile_struct_ty(
     context: &ModuleContext,
     writer: &mut impl Write,
     struct_ty: &surface::StructType,
-    report: &mut dyn FnMut(Diagnostic<FileId>),
+    report: &mut dyn FnMut(Diagnostic<usize>),
 ) -> io::Result<(String, Item)> {
     let (_, name) = &struct_ty.name;
     let id = format!("items[{}]", name);
@@ -210,7 +209,7 @@ fn compile_term_prec<'term>(
     context: &ModuleContext,
     term: &'term surface::Term,
     prec: Prec,
-    report: &mut dyn FnMut(Diagnostic<FileId>),
+    report: &mut dyn FnMut(Diagnostic<usize>),
 ) -> Cow<'term, str> {
     use itertools::Itertools;
 

--- a/crates/ddl/src/surface/grammar.lalrpop
+++ b/crates/ddl/src/surface/grammar.lalrpop
@@ -1,16 +1,16 @@
-use codespan::{ByteIndex, FileId, Span};
 use codespan_reporting::diagnostic::Diagnostic;
+use std::ops::Range;
 use std::sync::Arc;
 
 use crate::surface::{Alias, Item, Module, Pattern, StructType, Term, TypeField};
 use crate::lexer::Token;
 use crate::literal;
 
-grammar(file_id: FileId, report: &mut dyn FnMut(Diagnostic<FileId>));
+grammar(file_id: usize, report: &mut dyn FnMut(Diagnostic<usize>));
 
 extern {
-    type Location = ByteIndex;
-    type Error = Diagnostic<FileId>;
+    type Location = usize;
+    type Error = Diagnostic<usize>;
 
     enum Token {
         "doc comment" => Token::DocComment(<String>),
@@ -62,21 +62,21 @@ pub Module: Module = {
 Item: Item = {
     <doc: "doc comment"*>
     <start: @L> <name: Identifier> <ty: (":" <Term>)?> "=" <term: Term> ";" <end: @R> => {
-        let span = Span::new(start, end);
+        let range = start..end;
         let doc = Arc::from(doc);
 
-        Item::Alias(Alias { span, doc, name, ty, term })
+        Item::Alias(Alias { range, doc, name, ty, term })
     },
     <doc: "doc comment"*>
     <start: @L> "struct" <name: Identifier> "{"
         <mut fields: (<Field> ",")*>
         <last: Field?>
     "}" <end: @R> => {
-        let span = Span::from(start..end);
+        let range = start..end;
         let doc = Arc::from(doc);
         fields.extend(last);
 
-        Item::Struct(StructType { span, doc, name, fields })
+        Item::Struct(StructType { range, doc, name, fields })
     },
 };
 
@@ -90,7 +90,7 @@ Field: TypeField = {
 Pattern: Pattern = {
     <name: Identifier> => Pattern::Name(name.0, name.1),
     <start: @L> <literal: "numeric literal"> <end: @R> => {
-        Pattern::NumberLiteral(Span::new(start, end), literal)
+        Pattern::NumberLiteral(start..end, literal)
     },
 };
 
@@ -116,23 +116,23 @@ AppTerm: Term = {
 AtomicTerm: Term = {
     "(" <term: Term> ")" => term,
     <name: Identifier> => Term::Name(name.0, name.1),
-    <start: @L> "Host" <end: @R> => Term::Host(Span::new(start, end)),
-    <start: @L> "Format" <end: @R> => Term::Format(Span::new(start, end)),
-    <start: @L> "Kind" <end: @R> => Term::Kind(Span::new(start, end)),
+    <start: @L> "Host" <end: @R> => Term::Host(start..end),
+    <start: @L> "Format" <end: @R> => Term::Format(start..end),
+    <start: @L> "Kind" <end: @R> => Term::Kind(start..end),
     <start: @L> <literal: "numeric literal"> <end: @R> => {
-        Term::NumberLiteral(Span::new(start, end), literal)
+        Term::NumberLiteral(start..end, literal)
     },
     <start: @L> "if" <head: Term> "{" <if_true: Term> "}" "else" "{" <if_false: Term> "}" <end: @R> => {
-        Term::If(Span::new(start, end), Box::new(head), Box::new(if_true), Box::new(if_false))
+        Term::If(start..end, Box::new(head), Box::new(if_true), Box::new(if_false))
     },
     <start: @L> "match" <head: Term> "{" <mut branches: (<Pattern> "=>" <Term> ",")*> <last: (<Pattern> "=>" <Term>)?>"}" <end: @R> => {
         branches.extend(last);
-        Term::Match(Span::new(start, end), Box::new(head), branches)
+        Term::Match(start..end, Box::new(head), branches)
     },
 };
 
-Identifier: (Span, String) = {
+Identifier: (Range<usize>, String) = {
     <start: @L> <name: "identifier"> <end: @R> => {
-        (Span::new(start, end), name)
+        (start..end, name)
     },
 };

--- a/experiments/rust-prototype-v2/src/syntax/core.rs
+++ b/experiments/rust-prototype-v2/src/syntax/core.rs
@@ -3,7 +3,7 @@
 use moniker::{Binder, Embed, FreeVar, Nest, Scope, Var};
 use num_bigint::BigInt;
 use std::fmt;
-use std::ops;
+use std::ops::Range;
 use std::rc::Rc;
 
 use crate::syntax::pretty::{self, ToDoc};

--- a/experiments/rust-prototype-v2/src/syntax/raw.rs
+++ b/experiments/rust-prototype-v2/src/syntax/raw.rs
@@ -5,7 +5,7 @@ use codespan::ByteSpan;
 use moniker::{Binder, Embed, Nest, Scope, Var};
 use num_bigint::BigInt;
 use std::fmt;
-use std::ops;
+use std::ops::Range;
 use std::rc::Rc;
 
 use crate::syntax::pretty::{self, ToDoc};


### PR DESCRIPTION
Switch to using the simpler types defined in `codespan_reporting`. I'm probably going to deprecate `codespan` ultimately, so this a step in the right direction I think?